### PR TITLE
Cheap package conversion

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+#This file's existance makes peel a package.
+#It maybe should have more but it works as with peel being simple


### PR DESCRIPTION
So... bra....
Like I want to be able to submodule this in my python apps and call it all up... but I can't cause it's not a package.. like we could make it a REAL package or just slop it up by adding that emptyish **init**.py. Now you can `from peel.peel import *` rock

Like whatev. it's your deal.
